### PR TITLE
ignore SSL verify

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,6 +6,10 @@ import os
 import urllib.request
 import jsonschema
 
+# ignore ssl verify
+import ssl
+ssl._create_default_https_context = ssl._create_unverified_context
+
 #日本標準時
 JST = datetime.timezone(datetime.timedelta(hours=+9), 'JST')
 


### PR DESCRIPTION
```
urllib.error.URLError: <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificat
```

原因はわかりませんが、SSL verifyでエラーが出ているのでそのverifyを無効化しました。
※ローカルで同じエラーが発生し、また本コミットにより解決する事は確認済みです